### PR TITLE
fix: add basic flowtype for glob to fix flow runner

### DIFF
--- a/flow-typed/custom-definitions/glob.js
+++ b/flow-typed/custom-definitions/glob.js
@@ -1,0 +1,8 @@
+declare module 'glob' {    
+  declare type Callback = (err: ?Error, matches: ?Array<String>) => void;
+
+  declare module.exports: {
+    (f: string, opts?: any | Callback, callback?: Callback): void;
+    sync(pattern: string, options?: any): Array<string>;
+  };
+}


### PR DESCRIPTION
`npm run flow` is broken as there is no definition for glob. There is not currently a [flow-typed](https://github.com/flowtype/flow-typed) definition for the module, so I stubbed out a very basic flowtype that is being used by this code base.

Should we add flow into the commit/push pipeline to prevent future breaks? I don't see anything running flow in the workflow.