### PR TITLE
fix: prevent delete from sending multiple args in callback

### DIFF
--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,2 +1,2 @@
 // Warning: This file is automatically synced from https://github.com/ipfs/ci-sync so if you want to change it, please change it there and ask someone to sync all repositories.
-javascript()
+javascript(['nodejs_versions': ['8.11.1','9.2.0','10.0.0']])

--- a/src/index.js
+++ b/src/index.js
@@ -225,7 +225,10 @@ class FsDatastore {
    */
   delete (key /* : Key */, callback /* : Callback<void> */) /* : void */ {
     const parts = this._encode(key)
-    fs.unlink(parts.file, callback)
+    fs.unlink(parts.file, (err) => {
+      // Avoid injection of additional params, we only need the error
+      callback(err)
+    })
   }
 
   /**


### PR DESCRIPTION
This fixes an issue in node10 where unlink could call the callback as `callback(err, undefined)`. This resulted in test suite failures for ipfs-repo as it was attempting to use async/waterfall.

This PR simply enforces the callback only ever returning an error, if one exists.

The following chain would cause the callback being sent to `datastore.has` to undefined.
```js
        waterfall([
          (cb) => repo.datastore.delete(b, cb),
          (cb) => repo.datastore.has(b, cb)
        ], (err, exists) => {
          expect(err).to.not.exist()
          expect(exists).to.equal(false)
          done()
        })
```

This is related to the following issues, but is not the core cause, it is just causing test suite failures in node v10.
relates to https://github.com/ipfs/js-ipfs/issues/1347 
relates to https://github.com/ipfs/js-ipfs-repo/issues/167