### PR TITLE
Use fast-write-atomic instead of write-file-atomic

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,12 +36,12 @@
   "dependencies": {
     "async": "^2.6.1",
     "datastore-core": "~0.6.0",
+    "fast-write-atomic": "~0.2.0",
     "glob": "^7.1.3",
     "graceful-fs": "^4.1.11",
     "interface-datastore": "~0.6.0",
     "mkdirp": "~0.5.1",
-    "pull-stream": "^3.6.9",
-    "write-file-atomic": "^2.3.0"
+    "pull-stream": "^3.6.9"
   },
   "devDependencies": {
     "aegir": "^15.3.1",

--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ const setImmediate = require('async/setImmediate')
 const waterfall = require('async/series')
 const each = require('async/each')
 const mkdirp = require('mkdirp')
-const writeFile = require('write-file-atomic')
+const writeFile = require('fast-write-atomic')
 const path = require('path')
 
 const asyncFilter = require('interface-datastore').utils.asyncFilter


### PR DESCRIPTION
fast-write-atomic is 10-20% faster depending on the operating system,
mainly because it does not use fs.realpath() and so many promises.

This needs to be tested, especially on Windows.

I'm happy to move fast-write-atomic to the ipfs org if you want, I've put it on my profile for convenience of adding Travis etc.

See https://github.com/ipfs/js-ipfs/issues/1785 for more details.