### PR TITLE
fix: handle concurrent writes on windows

### DIFF
--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -153,4 +153,29 @@ describe('FsDatastore', () => {
       }
     })
   })
+
+  it('can survive concurrent writes', (done) => {
+    const dir = utils.tmpdir()
+    const fstore = new FsStore(dir)
+    const key = new Key('CIQGFTQ7FSI2COUXWWLOQ45VUM2GUZCGAXLWCTOKKPGTUWPXHBNIVOY')
+    const value = Buffer.from('Hello world')
+
+    parallel(
+      new Array(100).fill(0).map(() => {
+        return (cb) => {
+          fstore.put(key, value, cb)
+        }
+      }),
+      (err) => {
+        expect(err).to.not.exist()
+
+        fstore.get(key, (err, res) => {
+          expect(err).to.not.exist()
+          expect(res).to.deep.equal(value)
+
+          done()
+        })
+      }
+    )
+  })
 })


### PR DESCRIPTION
Windows can return EPERM errors when trying to rename temp files to files that already exist. In our case a file with a given name will always have the same content so if it's created while we are trying to also create it, we can reasonably assume it's ok to use.

If we want to be more thorough we could hash the contents of the new file.