### PR TITLE
fix: handle concurrent writes on windows

### DIFF
--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -172,4 +172,19 @@ describe('FsDatastore', () => {
       }
     })
   })
+
+  it('can survive concurrent writes', async () => {
+    const dir = utils.tmpdir()
+    const fstore = new FsStore(dir)
+    const key = new Key('CIQGFTQ7FSI2COUXWWLOQ45VUM2GUZCGAXLWCTOKKPGTUWPXHBNIVOY')
+    const value = Buffer.from('Hello world')
+
+    await Promise.all(
+      new Array(100).fill(0).map(() => fstore.put(key, value))
+    )
+
+    const res = await fstore.get(key)
+
+    expect(res).to.deep.equal(value)
+  })
 })


### PR DESCRIPTION
Windows can return EPERM errors when trying to rename temp files to files that already exist. In our case a file with a given name will always have the same content so if it's created while we are trying to also create it, we can reasonably assume it's ok to use.

If we want to be more thorough we could hash the contents of the new file.