### PR TITLE
feat: add streaming/cancellable API

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,14 +35,14 @@
   },
   "homepage": "https://github.com/ipfs/js-datastore-fs#readme",
   "dependencies": {
-    "datastore-core": "^1.0.0",
-    "fast-write-atomic": "~0.2.0",
+    "datastore-core": "^1.1.0",
+    "fast-write-atomic": "^0.2.0",
     "glob": "^7.1.3",
-    "interface-datastore": "~0.8.3",
+    "interface-datastore": "^1.0.2",
     "mkdirp": "^1.0.4"
   },
   "devDependencies": {
-    "aegir": "^21.10.2",
+    "aegir": "^22.0.0",
     "async-iterator-all": "^1.0.0",
     "chai": "^4.2.0",
     "cids": "~0.8.0",

--- a/src/index.js
+++ b/src/index.js
@@ -6,20 +6,16 @@ const mkdirp = require('mkdirp')
 const promisify = require('util').promisify
 const writeAtomic = promisify(require('fast-write-atomic'))
 const path = require('path')
-
-const filter = require('interface-datastore').utils.filter
-const take = require('interface-datastore').utils.take
-const map = require('interface-datastore').utils.map
-const sortAll = require('interface-datastore').utils.sortAll
-const IDatastore = require('interface-datastore')
+const {
+  Adapter, Key, Errors, utils: {
+    map
+  }
+} = require('interface-datastore')
 
 const noop = () => {}
 const fsAccess = promisify(fs.access || noop)
 const fsReadFile = promisify(fs.readFile || noop)
 const fsUnlink = promisify(fs.unlink || noop)
-
-const Key = IDatastore.Key
-const Errors = IDatastore.Errors
 
 async function writeFile (path, contents) {
   try {
@@ -47,63 +43,30 @@ async function writeFile (path, contents) {
  * Keys need to be sanitized before use, as they are written
  * to the file system as is.
  */
-class FsDatastore {
+class FsDatastore extends Adapter {
   constructor (location, opts) {
+    super()
+
     this.path = path.resolve(location)
     this.opts = Object.assign({}, {
       createIfMissing: true,
       errorIfExists: false,
       extension: '.data'
     }, opts)
-
-    if (this.opts.createIfMissing) {
-      this._openOrCreate()
-    } else {
-      this._open()
-    }
   }
 
   open () {
-    this._openOrCreate()
-  }
-
-  /**
-   * Check if the path actually exists.
-   * @private
-   * @returns {void}
-   */
-  _open () {
-    if (!fs.existsSync(this.path)) {
-      throw Errors.notFoundError(new Error(`Datastore directory: ${this.path} does not exist`))
-    }
-
-    if (this.opts.errorIfExists) {
-      throw Errors.dbOpenFailedError(new Error(`Datastore directory: ${this.path} already exists`))
-    }
-  }
-
-  /**
-   * Create the directory to hold our data.
-   *
-   * @private
-   * @returns {void}
-   */
-  _create () {
-    mkdirp.sync(this.path, { fs: fs })
-  }
-
-  /**
-   * Tries to open, and creates if the open fails.
-   *
-   * @private
-   * @returns {void}
-   */
-  _openOrCreate () {
     try {
-      this._open()
+      if (!fs.existsSync(this.path)) {
+        throw Errors.notFoundError(new Error(`Datastore directory: ${this.path} does not exist`))
+      }
+
+      if (this.opts.errorIfExists) {
+        throw Errors.dbOpenFailedError(new Error(`Datastore directory: ${this.path} already exists`))
+      }
     } catch (err) {
-      if (err.code === 'ERR_NOT_FOUND') {
-        this._create()
+      if (err.code === 'ERR_NOT_FOUND' && this.opts.createIfMissing) {
+        mkdirp.sync(this.path, { fs: fs })
         return
       }
 
@@ -165,17 +128,18 @@ class FsDatastore {
   }
 
   /**
-   * Store the given value under the key.
+   * Store the given value under the key
    *
    * @param {Key} key
    * @param {Buffer} val
+   * @param {Object} options
    * @returns {Promise<void>}
    */
   async put (key, val) {
     const parts = this._encode(key)
     try {
       await mkdirp(parts.dir, { fs: fs })
-      await writeFile(parts.file, val)
+      await writeFile(parts.file, val, options)
     } catch (err) {
       throw Errors.dbWriteFailedError(err)
     }
@@ -185,9 +149,10 @@ class FsDatastore {
    * Read from the file system without extension.
    *
    * @param {Key} key
+   * @param {Object} options
    * @returns {Promise<Buffer>}
    */
-  async getRaw (key) {
+  async getRaw (key, options = {}) {
     const parts = this._encode(key)
     let file = parts.file
     file = file.slice(0, -this.opts.extension.length)
@@ -204,6 +169,7 @@ class FsDatastore {
    * Read from the file system.
    *
    * @param {Key} key
+   * @param {Object} options
    * @returns {Promise<Buffer>}
    */
   async get (key) {
@@ -237,6 +203,7 @@ class FsDatastore {
    * Delete the record under the given key.
    *
    * @param {Key} key
+   * @param {Object} options
    * @returns {Promise<void>}
    */
   async delete (key) {
@@ -252,40 +219,7 @@ class FsDatastore {
     }
   }
 
-  /**
-   * Create a new batch object.
-   *
-   * @returns {Batch}
-   */
-  batch () {
-    const puts = []
-    const deletes = []
-    return {
-      put (key, value) {
-        puts.push({ key: key, value: value })
-      },
-      delete (key) {
-        deletes.push(key)
-      },
-      commit: () /* :  Promise<void> */ => {
-        return Promise.all(
-          puts
-            .map((put) => this.put(put.key, put.value))
-            .concat(
-              deletes.map((del) => this.delete(del))
-            )
-        )
-      }
-    }
-  }
-
-  /**
-   * Query the store.
-   *
-   * @param {Object} q
-   * @returns {Iterable}
-   */
-  query (q) {
+  async * _all (q) { // eslint-disable-line require-await
     // glob expects a POSIX path
     const prefix = q.prefix || '**'
     const pattern = path
@@ -293,9 +227,9 @@ class FsDatastore {
       .split(path.sep)
       .join('/')
     const files = glob.sync(pattern)
-    let it
+
     if (!q.keysOnly) {
-      it = map(files, async (f) => {
+      yield * map(files, async (f) => {
         const buf = await fsReadFile(f)
         return {
           key: this._decode(f),
@@ -303,33 +237,9 @@ class FsDatastore {
         }
       })
     } else {
-      it = map(files, f => ({ key: this._decode(f) }))
+      yield * map(files, f => ({ key: this._decode(f) }))
     }
-
-    if (Array.isArray(q.filters)) {
-      it = q.filters.reduce((it, f) => filter(it, f), it)
-    }
-
-    if (Array.isArray(q.orders)) {
-      it = q.orders.reduce((it, f) => sortAll(it, f), it)
-    }
-
-    if (q.offset != null) {
-      let i = 0
-      it = filter(it, () => i++ >= q.offset)
-    }
-
-    if (q.limit != null) {
-      it = take(it, q.limit)
-    }
-
-    return it
   }
-
-  /**
-   * Close the store.
-   */
-  close () { }
 }
 
 module.exports = FsDatastore

--- a/src/index.js
+++ b/src/index.js
@@ -132,14 +132,13 @@ class FsDatastore extends Adapter {
    *
    * @param {Key} key
    * @param {Buffer} val
-   * @param {Object} options
    * @returns {Promise<void>}
    */
   async put (key, val) {
     const parts = this._encode(key)
     try {
       await mkdirp(parts.dir, { fs: fs })
-      await writeFile(parts.file, val, options)
+      await writeFile(parts.file, val)
     } catch (err) {
       throw Errors.dbWriteFailedError(err)
     }
@@ -149,10 +148,9 @@ class FsDatastore extends Adapter {
    * Read from the file system without extension.
    *
    * @param {Key} key
-   * @param {Object} options
    * @returns {Promise<Buffer>}
    */
-  async getRaw (key, options = {}) {
+  async getRaw (key) {
     const parts = this._encode(key)
     let file = parts.file
     file = file.slice(0, -this.opts.extension.length)
@@ -169,7 +167,6 @@ class FsDatastore extends Adapter {
    * Read from the file system.
    *
    * @param {Key} key
-   * @param {Object} options
    * @returns {Promise<Buffer>}
    */
   async get (key) {
@@ -203,7 +200,6 @@ class FsDatastore extends Adapter {
    * Delete the record under the given key.
    *
    * @param {Key} key
-   * @param {Object} options
    * @returns {Promise<void>}
    */
   async delete (key) {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -43,19 +43,23 @@ describe('FsDatastore', () => {
         () => new FsStore(dir)
       ).to.not.throw()
     })
+  })
 
+  describe('open', () => {
     it('createIfMissing: false - folder missing', () => {
       const dir = utils.tmpdir()
+      const store = new FsStore(dir, { createIfMissing: false })
       expect(
-        () => new FsStore(dir, { createIfMissing: false })
+        () => store.open()
       ).to.throw()
     })
 
     it('errorIfExists: true - folder exists', () => {
       const dir = utils.tmpdir()
       mkdirp.sync(dir)
+      new FsStore(dir, { errorIfExists: true })
       expect(
-        () => new FsStore(dir, { errorIfExists: true })
+        () => store.open()
       ).to.throw()
     })
   })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -57,7 +57,7 @@ describe('FsDatastore', () => {
     it('errorIfExists: true - folder exists', () => {
       const dir = utils.tmpdir()
       mkdirp.sync(dir)
-      new FsStore(dir, { errorIfExists: true })
+      const store = new FsStore(dir, { errorIfExists: true })
       expect(
         () => store.open()
       ).to.throw()


### PR DESCRIPTION
Upgrades to the latest interface-datastore which includes streaming APIs and passing AbortControllers.

Uses the new Adapter class to implement these with minimal code changes.

* Splits out open so it's not called from the constructor any more
* Combines some of the private methods to make code flow simpler
* Removes code duplicated by the interface adapter