### PR TITLE
fix: remove node buffers

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
   },
   "homepage": "https://github.com/ipfs/js-datastore-fs#readme",
   "dependencies": {
-    "datastore-core": "ipfs/js-datastore-core#fix/remove-node-buffers",
+    "datastore-core": "^2.0.0",
     "fast-write-atomic": "^0.2.0",
-    "interface-datastore": "ipfs/interface-datastore#fix/remove-node-buffer",
+    "interface-datastore": "^2.0.0",
     "it-glob": "0.0.8",
     "mkdirp": "^1.0.4"
   },

--- a/package.json
+++ b/package.json
@@ -5,10 +5,7 @@
   "leadMaintainer": "Alex Potsides <alex.potsides@protocol.ai>",
   "main": "src/index.js",
   "scripts": {
-    "test": "aegir test",
-    "test:node": "aegir test -t node",
-    "test:browser": "aegir test -t browser",
-    "test:webworker": "aegir test -t webworker",
+    "test": "aegir test -t node",
     "build": "aegir build",
     "lint": "aegir lint",
     "release": "aegir release",
@@ -35,19 +32,20 @@
   },
   "homepage": "https://github.com/ipfs/js-datastore-fs#readme",
   "dependencies": {
-    "datastore-core": "^1.1.0",
+    "datastore-core": "ipfs/js-datastore-core#fix/remove-node-buffers",
     "fast-write-atomic": "^0.2.0",
-    "glob": "^7.1.3",
-    "interface-datastore": "^1.0.2",
+    "interface-datastore": "ipfs/interface-datastore#fix/remove-node-buffer",
+    "it-glob": "0.0.8",
     "mkdirp": "^1.0.4"
   },
   "devDependencies": {
-    "aegir": "^22.0.0",
+    "aegir": "^25.0.0",
     "async-iterator-all": "^1.0.0",
     "chai": "^4.2.0",
-    "cids": "~0.8.0",
+    "cids": "^0.8.3",
     "detect-node": "^2.0.4",
     "dirty-chai": "^2.0.1",
+    "ipfs-utils": "^2.3.1",
     "memdown": "^5.1.0",
     "rimraf": "^3.0.2"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -239,7 +239,11 @@ class FsDatastore extends Adapter {
             value: buf
           }
         } catch (err) {
-          console.info(err)
+          // if keys are removed from the datastore while the query is
+          // running, we may encounter missing files.
+          if (err.code !== 'ENOENT') {
+            throw err
+          }
         }
       }
     } else {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -16,6 +16,8 @@ const utils = require('interface-datastore').utils
 const ShardingStore = require('datastore-core').ShardingDatastore
 const sh = require('datastore-core').shard
 const isNode = require('detect-node')
+const TextEncoder = require('ipfs-utils/src/text-encoder')
+const utf8Encoder = new TextEncoder('utf8')
 
 const FsStore = require('../src')
 
@@ -87,7 +89,7 @@ describe('FsDatastore', () => {
     const fs = new FsStore(dir)
     const key = new Key('1234')
 
-    await fs.put(key, Buffer.from([0, 1, 2, 3]))
+    await fs.put(key, Uint8Array.from([0, 1, 2, 3]))
     await fs.delete(key)
 
     try {
@@ -181,7 +183,7 @@ describe('FsDatastore', () => {
     const dir = utils.tmpdir()
     const fstore = new FsStore(dir)
     const key = new Key('CIQGFTQ7FSI2COUXWWLOQ45VUM2GUZCGAXLWCTOKKPGTUWPXHBNIVOY')
-    const value = Buffer.from('Hello world')
+    const value = utf8Encoder.encode('Hello world')
 
     await Promise.all(
       new Array(100).fill(0).map(() => fstore.put(key, value))


### PR DESCRIPTION
Updates to the latest changes from interface-datastore and datastore-core

Depends on:

- [x] https://github.com/ipfs/interface-datastore/pull/43
- [x] https://github.com/ipfs/js-datastore-core/pull/27

BREAKING CHANGE: only uses Uint8Arrays internally