### PR TITLE
fix: only remove extension from path when it is non-empty

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,12 +39,10 @@
     "mkdirp": "^1.0.4"
   },
   "devDependencies": {
-    "aegir": "^25.0.0",
+    "aegir": "^26.0.0",
     "async-iterator-all": "^1.0.0",
-    "chai": "^4.2.0",
-    "cids": "^0.8.3",
+    "cids": "^1.0.0",
     "detect-node": "^2.0.4",
-    "dirty-chai": "^2.0.1",
     "ipfs-utils": "^2.3.1",
     "memdown": "^5.1.0",
     "rimraf": "^3.0.2"

--- a/src/index.js
+++ b/src/index.js
@@ -122,7 +122,12 @@ class FsDatastore extends Adapter {
    */
   async putRaw (key, val) {
     const parts = this._encode(key)
-    const file = parts.file.slice(0, -this.opts.extension.length)
+    let file = parts.file
+
+    if (this.opts.extension.length) {
+      file = parts.file.slice(0, -this.opts.extension.length)
+    }
+
     await mkdirp(parts.dir, { fs: fs })
     await writeFile(file, val)
   }
@@ -154,7 +159,11 @@ class FsDatastore extends Adapter {
   async getRaw (key) {
     const parts = this._encode(key)
     let file = parts.file
-    file = file.slice(0, -this.opts.extension.length)
+
+    if (this.opts.extension.length) {
+      file = file.slice(0, -this.opts.extension.length)
+    }
+
     let data
     try {
       data = await fsReadFile(file)

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,9 +1,7 @@
 /* eslint-env mocha */
 'use strict'
 
-const chai = require('chai')
-chai.use(require('dirty-chai'))
-const expect = chai.expect
+const { expect } = require('aegir/utils/chai')
 const path = require('path')
 const promisify = require('util').promisify
 const noop = () => {}
@@ -190,6 +188,21 @@ describe('FsDatastore', () => {
     )
 
     const res = await fstore.get(key)
+
+    expect(res).to.deep.equal(value)
+  })
+
+  it('can survive putRaw and getRaw with an empty extension', async () => {
+    const dir = utils.tmpdir()
+    const fstore = new FsStore(dir, {
+      extension: ''
+    })
+    const key = new Key('CIQGFTQ7FSI2COUXWWLOQ45VUM2GUZCGAXLWCTOKKPGTUWPXHBNIVOY')
+    const value = utf8Encoder.encode('Hello world')
+
+    await fstore.putRaw(key, value)
+
+    const res = await fstore.getRaw(key)
 
     expect(res).to.deep.equal(value)
   })


### PR DESCRIPTION
The default config for root datastores is to have an empty string extension, but if you use putRaw or getRaw as the sharded datastore does, stripping the extension can cause the final file path to be an empty string, so guard on the extension not having a valid length.