### PR TITLE
feat: parallel block writes

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "interface-datastore": "^5.1.1",
     "it-glob": "0.0.13",
     "it-map": "^1.0.5",
+    "it-parallel-batch": "^1.0.9",
     "mkdirp": "^1.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
When using the `putMany` datastore method, write blocks in parallel up to a configurable limit.

In local testing this almost doubles the throughput of this module for multi-block writes.