### PR TITLE
feat!: publish module as ESM only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,6 @@ updates:
     interval: daily
     time: "10:00"
   open-pull-requests-limit: 10
+  commit-message:
+    prefix: "deps"
+    prefix-development: "deps(dev)"

--- a/README.md
+++ b/README.md
@@ -1,29 +1,25 @@
-# js-datastore-fs <!-- omit in toc -->
+# datastore-fs <!-- omit in toc -->
 
-[![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://ipn.io)
-[![](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](http://ipfs.io/)
-[![](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
-[![standard-readme compliant](https://img.shields.io/badge/standard--readme-OK-green.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
-[![Build Status](https://github.com/ipfs/js-datastore-fs/actions/workflows/js-test-and-release.yml/badge.svg?branch=master)](https://github.com/ipfs/js-datastore-fs/actions/workflows/js-test-and-release.yml)
-[![Codecov](https://codecov.io/gh/ipfs/js-datastore-fs/branch/master/graph/badge.svg)](https://codecov.io/gh/ipfs/js-datastore-fs)
-[![Dependency Status](https://david-dm.org/ipfs/js-datastore-fs.svg?style=flat-square)](https://david-dm.org/ipfs/js-datastore-fs)
-[![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/feross/standard)
-![](https://img.shields.io/badge/npm-%3E%3D3.0.0-orange.svg?style=flat-square)
-![](https://img.shields.io/badge/Node.js-%3E%3D8.0.0-orange.svg?style=flat-square)
+[![ipfs.io](https://img.shields.io/badge/project-IPFS-blue.svg?style=flat-square)](http://ipfs.io)
+[![IRC](https://img.shields.io/badge/freenode-%23ipfs-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23ipfs)
+[![Discord](https://img.shields.io/discord/806902334369824788?style=flat-square)](https://discord.gg/ipfs)
+[![codecov](https://img.shields.io/codecov/c/github/ipfs/js-datastore-fs.svg?style=flat-square)](https://codecov.io/gh/ipfs/js-datastore-fs)
+[![CI](https://img.shields.io/github/workflow/status/ipfs/js-datastore-fs/test%20&%20maybe%20release/master?style=flat-square)](https://github.com/ipfs/js-datastore-fs/actions/workflows/js-test-and-release.yml)
 
-> Datastore implementation with file system backend.
+> Datastore implementation with file system backend
 
-## Table of Contents <!-- omit in toc -->
+## Table of contents <!-- omit in toc -->
 
 - [Install](#install)
 - [Usage](#usage)
 - [Contribute](#contribute)
 - [License](#license)
+- [Contribute](#contribute-1)
 
 ## Install
 
-```
-$ npm install datastore-fs
+```console
+$ npm i datastore-fs
 ```
 
 ## Usage
@@ -44,4 +40,15 @@ This repository falls under the IPFS [Code of Conduct](https://github.com/ipfs/c
 
 ## License
 
-[MIT](LICENSE)
+Licensed under either of
+
+- Apache 2.0, ([LICENSE-APACHE](LICENSE-APACHE) / <http://www.apache.org/licenses/LICENSE-2.0>)
+- MIT ([LICENSE-MIT](LICENSE-MIT) / <http://opensource.org/licenses/MIT>)
+
+## Contribute
+
+Feel free to join in. All welcome. Open an [issue](https://github.com/ipfs/js-ipfs-unixfs-importer/issues)!
+
+This repository falls under the IPFS [Code of Conduct](https://github.com/ipfs/community/blob/master/code-of-conduct.md).
+
+[![](https://cdn.rawgit.com/jbenet/contribute-ipfs-gif/master/img/contribute.gif)](https://github.com/ipfs/community/blob/master/CONTRIBUTING.md)

--- a/package.json
+++ b/package.json
@@ -23,27 +23,33 @@
     "node": ">=16.0.0",
     "npm": ">=7.0.0"
   },
-  "main": "src/index.js",
   "type": "module",
-  "types": "types/src/index.d.ts",
+  "types": "./dist/src/index.d.ts",
   "typesVersions": {
     "*": {
       "*": [
-        "types/*",
-        "types/src/*"
+        "*",
+        "dist/*",
+        "dist/src/*",
+        "dist/src/*/index"
       ],
-      "types/*": [
-        "types/*",
-        "types/src/*"
+      "src/*": [
+        "*",
+        "dist/*",
+        "dist/src/*",
+        "dist/src/*/index"
       ]
     }
   },
   "files": [
-    "*",
+    "src",
+    "dist",
+    "!dist/test",
     "!**/*.tsbuildinfo"
   ],
   "exports": {
     ".": {
+      "types": "./dist/src/index.d.ts",
       "import": "./src/index.js"
     }
   },
@@ -80,15 +86,15 @@
               "release": "patch"
             },
             {
-              "type": "chore",
-              "release": "patch"
-            },
-            {
               "type": "docs",
               "release": "patch"
             },
             {
               "type": "test",
+              "release": "patch"
+            },
+            {
+              "type": "deps",
               "release": "patch"
             },
             {
@@ -118,7 +124,11 @@
               },
               {
                 "type": "docs",
-                "section": "Trivial Changes"
+                "section": "Documentation"
+              },
+              {
+                "type": "deps",
+                "section": "Dependencies"
               },
               {
                 "type": "test",
@@ -129,30 +139,24 @@
         }
       ],
       "@semantic-release/changelog",
-      [
-        "@semantic-release/npm",
-        {
-          "pkgRoot": "dist"
-        }
-      ],
+      "@semantic-release/npm",
       "@semantic-release/github",
       "@semantic-release/git"
     ]
   },
   "scripts": {
-    "clean": "rimraf dist types",
-    "prepare": "aegir build --no-bundle && cp -R types dist",
-    "lint": "aegir ts -p check && aegir lint",
-    "build": "aegir build --esm-tests",
-    "release": "semantic-release",
+    "clean": "aegir clean",
+    "lint": "aegir lint",
+    "build": "aegir build",
+    "release": "aegir release",
     "test": "aegir test",
     "test:node": "aegir test -t node",
     "dep-check": "aegir dep-check -i rimraf"
   },
   "dependencies": {
-    "datastore-core": "^7.0.0",
+    "datastore-core": "^8.0.1",
     "fast-write-atomic": "^0.2.0",
-    "interface-datastore": "^6.0.2",
+    "interface-datastore": "^7.0.0",
     "it-glob": "^1.0.1",
     "it-map": "^1.0.5",
     "it-parallel-batch": "^1.0.9",
@@ -161,10 +165,10 @@
   "devDependencies": {
     "@types/mkdirp": "^1.0.2",
     "@types/rimraf": "^3.0.2",
-    "aegir": "^36.1.3",
+    "aegir": "^37.5.0",
     "async-iterator-all": "^1.0.0",
     "detect-node": "^2.0.4",
-    "interface-datastore-tests": "^2.0.3",
+    "interface-datastore-tests": "^3.0.0",
     "ipfs-utils": "^9.0.4",
     "memdown": "^6.0.0",
     "rimraf": "^3.0.2"

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,5 +1,5 @@
 /* eslint-env mocha */
-import { expect } from 'aegir/utils/chai.js'
+import { expect } from 'aegir/chai'
 import path from 'path'
 import { promisify } from 'util'
 import mkdirp from 'mkdirp'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "extends": "aegir/src/config/tsconfig.aegir.json",
   "compilerOptions": {
-    "outDir": "types"
+    "outDir": "dist",
+    "emitDeclarationOnly": true
   },
   "include": [
     "src",


### PR DESCRIPTION
BREAKING CHANGE: this module used to be dual published as CJS/ESM, now it is just ESM